### PR TITLE
Remove completedAt and assignedTo fields from AI prompt generation

### DIFF
--- a/frontend/src/constants/prompts.js
+++ b/frontend/src/constants/prompts.js
@@ -68,8 +68,6 @@ INSTRUCTIONS:
                    }
                  ],
                  "status": "pending",
-                 "completedAt": null,
-                 "assignedTo": null,
                  "estimatedHours": "Realistic hours based on task complexity and experience level"
                }
              ]


### PR DESCRIPTION
Removed completedAt and assignedTo fields from the AI prompt. 
These fields are managed in the Task card functionality. 
