### PR TITLE
feature: Added JSON validation for AI-generated roadmaps

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,8 @@
         "react-dom": "^19.1.0",
         "react-hot-toast": "^2.5.2",
         "react-markdown": "^10.1.0",
-        "react-router-dom": "^7.6.2"
+        "react-router-dom": "^7.6.2",
+        "zod": "^3.25.75"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -5367,6 +5368,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.75",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.75.tgz",
+      "integrity": "sha512-OhpzAmVzabPOL6C3A3gpAifqr9MqihV/Msx3gor2b2kviCgcb+HM9SEOpMWwwNp9MRunWnhtAKUoo0AHhjyPPg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zwitch": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,8 @@
     "react-dom": "^19.1.0",
     "react-hot-toast": "^2.5.2",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^7.6.2"
+    "react-router-dom": "^7.6.2",
+    "zod": "^3.25.75"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/frontend/src/constants/messages.js
+++ b/frontend/src/constants/messages.js
@@ -40,7 +40,8 @@ export const MESSAGES = {
     NO_DATE: 'N/A',
     INVALID_ROADMAP_CONTENT: 'Failed to parse roadmap content',
     ROADMAP_PARSE_FAILED: 'Roadmap data could not be parsed. Please regenerate your project roadmap.',
-    ROADMAP_INCOMPLETE: 'Roadmap data is incomplete. Please regenerate your project roadmap.'
+    ROADMAP_INCOMPLETE: 'Roadmap data is incomplete. Please regenerate your project roadmap.',
+    ROADMAP_VALIDATION_FAILED: 'Roadmap validation failed. Please regenerate your project roadmap.'
   }
 };
 

--- a/frontend/src/hooks/useProjectSave.js
+++ b/frontend/src/hooks/useProjectSave.js
@@ -4,6 +4,7 @@ import { showSuccessToast, showErrorToast } from '@/utils/toastUtils';
 import { createISOTimestamp } from '@/utils/dateUtils';
 import { MESSAGES } from '@/constants/messages';
 import { MESSAGE_TYPES } from '@/constants/messageTypes';
+import { validateRoadmapContent, getValidationErrorMessage } from '@/utils/roadmapValidation';
 
 /**
  * Custom hook for project saving functionality
@@ -38,6 +39,14 @@ export const useProjectSave = (messages, formValues) => {
         throw new Error(MESSAGES.ERROR.NO_ROADMAP);
       }
 
+      // Validate roadmap content before saving
+      const validationResult = validateRoadmapContent(roadmapMessage.content);
+      if (!validationResult.isValid) {
+        const errorMessage = getValidationErrorMessage(validationResult);
+        console.error('Roadmap validation failed:', validationResult);
+        throw new Error(errorMessage || MESSAGES.VALIDATION.ROADMAP_PARSE_FAILED);
+      }
+
       const projectData = {
         title: formValues?.title || MESSAGES.ACTIONS.DEFAULT_TITLE,
         content: roadmapMessage.content,
@@ -54,7 +63,7 @@ export const useProjectSave = (messages, formValues) => {
       }
     } catch (error) {
       console.error('Error saving project:', error);
-      showErrorToast(MESSAGES.ERROR.PROJECT_SAVE_FAILED);
+      showErrorToast(error.message || MESSAGES.ERROR.PROJECT_SAVE_FAILED);
       throw error;
     } finally {
       setSaving(false);

--- a/frontend/src/services/projectService.js
+++ b/frontend/src/services/projectService.js
@@ -2,8 +2,7 @@ import { supabase } from '@/lib/supabase';
 import { MESSAGES } from '@/constants/messages';
 
 /**
- *  Project Service
- * Save a new project to the database
+ * Project Service
  * 
  * Handles all project-related database operations including:
  * - Saving new projects with roadmap content
@@ -12,20 +11,17 @@ import { MESSAGES } from '@/constants/messages';
  * - Error handling and response formatting
  * 
  * All functions return response objects with success/error status.
+ */
+
+/**
+ * Save a new project to the database
+ * 
  * @param {Object} projectData - Project data to save
  * @param {string} projectData.title - Project title
  * @param {string} projectData.content - Project roadmap content
- * @returns {Promise<Object>} - Result with success status and project ID or error
+ * @returns {Promise<Object>} Result with success status and project ID or error
  */
-
-
-
 export const saveProject = async (projectData) => {
-  // TODO: Add validation for projectData (PR feedback: data integrity)
-  // TODO: Add user_id to the saved project
-  // TODO: Add project metadata (timeline, technologies, scope) to database
-// TODO: Add task status update API endpoint integration
-// TODO: Add project progress persistence functionality
   try {
     // Get current authenticated user
     const { data: { user }, error: authError } = await supabase.auth.getUser();
@@ -57,8 +53,9 @@ export const saveProject = async (projectData) => {
 
 /**
  * Retrieve a project by ID
+ * 
  * @param {string} projectId - Project ID to retrieve
- * @returns {Promise<Object>} - Result with project data or error
+ * @returns {Promise<Object>} Result with project data or error
  */
 export const getProject = async (projectId) => {
   try {

--- a/frontend/src/utils/promptBuilder.js
+++ b/frontend/src/utils/promptBuilder.js
@@ -1,14 +1,14 @@
 /**
  * Prompt Builder Utility
  * 
- * Handles dynamic prompt generation by replacing variables
- * with actual project data
+ * Handles dynamic prompt generation by replacing variables with project data
  */
 
 import { PROMPT_VARIABLES, ROADMAP_GENERATION_PROMPT } from '@/constants/prompts';
 
 /**
  * Builds a roadmap generation prompt with actual project data
+ * 
  * @param {Object} projectData - Project information
  * @param {string} projectData.title - Project title
  * @param {string} projectData.description - Project description
@@ -16,7 +16,7 @@ import { PROMPT_VARIABLES, ROADMAP_GENERATION_PROMPT } from '@/constants/prompts
  * @param {string} projectData.experienceLevel - Developer experience level
  * @param {string} projectData.technologies - Technologies to use
  * @param {string} projectData.scope - Project scope
- * @returns {string} - Formatted prompt with actual values
+ * @returns {string} Formatted prompt with actual values
  */
 export const buildRoadmapPrompt = (projectData) => {
   const {
@@ -55,8 +55,9 @@ export const buildRoadmapPrompt = (projectData) => {
 
 /**
  * Validates if all required project data is present
+ * 
  * @param {Object} projectData - Project information
- * @returns {Object} - Validation result with isValid boolean and missing fields array
+ * @returns {Object} Validation result with isValid boolean and missing fields array
  */
 export const validateProjectData = (projectData) => {
   const requiredFields = ['title', 'description', 'timeline', 'experienceLevel'];

--- a/frontend/src/utils/roadmapValidation.js
+++ b/frontend/src/utils/roadmapValidation.js
@@ -1,0 +1,191 @@
+/**
+ * Roadmap Validation Utility using Zod
+ * 
+ * Validates AI-generated roadmap JSON structure before saving to database.
+ * Handles markdown code block stripping and schema validation
+ * prevent unexpected data from being stored.
+ * 
+ * @module roadmapValidation
+ * @requires zod
+ * @requires @/constants/messages
+ * @requires @/constants/roadmap
+ */
+
+import { z } from 'zod';
+import { MESSAGES } from '@/constants/messages';
+
+/**
+ * Zod schema definitions for roadmap validation
+ * 
+ * Each schema defines the structure and validation rules for different
+ * components of the roadmap data structure.
+ */
+
+/**
+ * Resource schema for learning materials and tools
+ * @type {z.ZodObject}
+ */
+const ResourceSchema = z.object({
+  name: z.string().min(1, MESSAGES.VALIDATION.ROADMAP_INCOMPLETE),
+  url: z.string().optional() // AI provides URLs, but they might not always be valid
+});
+
+/**
+ * Task schema for individual project tasks
+ * @type {z.ZodObject}
+ */
+const TaskSchema = z.object({
+  id: z.string().min(1, MESSAGES.VALIDATION.ROADMAP_INCOMPLETE),
+  title: z.string().min(1, MESSAGES.VALIDATION.ROADMAP_INCOMPLETE),
+  description: z.string().min(1, MESSAGES.VALIDATION.ROADMAP_INCOMPLETE),
+  resources: z.array(ResourceSchema).default([]),
+  status: z.string().default('pending'), // AI always sets to "pending"
+  estimatedHours: z.union([z.string().min(1), z.number().positive()]).transform(val => 
+    typeof val === 'number' ? val.toString() : val
+  )
+});
+
+/**
+ * Milestone schema for project milestones
+ * @type {z.ZodObject}
+ */
+const MilestoneSchema = z.object({
+  id: z.string().min(1, MESSAGES.VALIDATION.ROADMAP_INCOMPLETE),
+  title: z.string().min(1, MESSAGES.VALIDATION.ROADMAP_INCOMPLETE),
+  timeline: z.string().min(1, MESSAGES.VALIDATION.ROADMAP_INCOMPLETE),
+  order: z.number(), // AI provides numbers, no need for positive integer validation
+  tasks: z.array(TaskSchema).min(1, MESSAGES.VALIDATION.ROADMAP_INCOMPLETE)
+});
+
+/**
+ * Phase schema for project phases
+ * @type {z.ZodObject}
+ */
+const PhaseSchema = z.object({
+  id: z.string().min(1, MESSAGES.VALIDATION.ROADMAP_INCOMPLETE),
+  title: z.string().min(1, MESSAGES.VALIDATION.ROADMAP_INCOMPLETE),
+  timeline: z.string().min(1, MESSAGES.VALIDATION.ROADMAP_INCOMPLETE),
+  order: z.number(), // AI provides numbers, no need for positive integer validation
+  milestones: z.array(MilestoneSchema).min(1, MESSAGES.VALIDATION.ROADMAP_INCOMPLETE)
+});
+
+/**
+ * Metadata schema for project information
+ * @type {z.ZodObject}
+ */
+const MetadataSchema = z.object({
+  title: z.string().min(1, MESSAGES.VALIDATION.ROADMAP_INCOMPLETE),
+  description: z.string().min(1, MESSAGES.VALIDATION.ROADMAP_INCOMPLETE),
+  timeline: z.string().min(1, MESSAGES.VALIDATION.ROADMAP_INCOMPLETE),
+  experienceLevel: z.string().min(1, MESSAGES.VALIDATION.ROADMAP_INCOMPLETE),
+  technologies: z.string().min(1, MESSAGES.VALIDATION.ROADMAP_INCOMPLETE),
+  scope: z.string().min(1, MESSAGES.VALIDATION.ROADMAP_INCOMPLETE),
+  version: z.string().min(1, MESSAGES.VALIDATION.ROADMAP_INCOMPLETE)
+});
+
+/**
+ * Main roadmap schema that validates the complete roadmap structure
+ * @type {z.ZodObject}
+ */
+const RoadmapSchema = z.object({
+  metadata: MetadataSchema,
+  summary: z.string().min(1, MESSAGES.VALIDATION.ROADMAP_INCOMPLETE),
+  phases: z.array(PhaseSchema).min(1, MESSAGES.VALIDATION.ROADMAP_INCOMPLETE)
+});
+
+/**
+ * Strips markdown code blocks from content
+ * 
+ * Removes markdown formatting from AI responses that wrap JSON in code blocks.
+ * AI consistently uses ```json format for JSON responses so I strip it 
+ * 
+ * @param {string} content - Content that may contain markdown code blocks
+ * @returns {string} Content with markdown code blocks removed
+ */
+const stripMarkdownCodeBlocks = (content) => {
+  if (!content || typeof content !== 'string') return content;
+  
+  return content
+    .replace(/^```json\s*\n?/i, '')  // Remove opening ```json
+    .replace(/\n?```\s*$/i, '')      // Remove closing ```
+    .trim();
+};
+
+/**
+ * Validates AI-generated roadmap JSON content
+ * 
+ * Performs comprehensive validation of roadmap data including:
+ * Markdown code block stripping
+ * JSON parsing validation
+ * Schema structure validation using Zod
+ * 
+ * @param {string} content - Raw AI response content that may contain markdown
+ * @returns {Object} Validation result object
+ * @returns {boolean} returns.isValid - Whether the content passed all validations
+ * @returns {string[]} returns.errors - Array of validation error messages
+ * @returns {string[]} returns.warnings - Array of validation warning messages
+ */
+export const validateRoadmapContent = (content) => {
+  const result = {
+    isValid: false,
+    errors: [],
+    warnings: []
+  };
+
+  if (!content || typeof content !== 'string') {
+    result.errors.push(MESSAGES.VALIDATION.ROADMAP_INCOMPLETE);
+    return result;
+  }
+
+  // Strip markdown code blocks
+  const cleanedContent = stripMarkdownCodeBlocks(content);
+
+  // Validate JSON parsing
+  let parsedContent;
+  try {
+    parsedContent = JSON.parse(cleanedContent);
+  } catch (error) {
+    result.errors.push(`${MESSAGES.VALIDATION.INVALID_ROADMAP_CONTENT}: ${error.message}`);
+    return result;
+  }
+
+  // Validate with Zod schema
+  const validationResult = RoadmapSchema.safeParse(parsedContent);
+  
+  if (!validationResult.success) {
+    // Convert Zod errors to proper format
+    result.errors = validationResult.error.issues.map(issue => {
+      const path = issue.path.join('.');
+      return `${path}: ${issue.message}`;
+    });
+  } else {
+    result.isValid = true;
+  }
+
+  return result;
+};
+
+/**
+ *error message for validation failures
+ * 
+ * Converts technical validation errors into user-readable messages.
+ * Limits the number of errors shown to avoid overwhelming the user.
+ * 
+ * @param {Object} validationResult - Result from validateRoadmapContent
+ * @param {boolean} validationResult.isValid - Whether validation passed
+ * @param {string[]} validationResult.errors - Array of validation errors
+ * @param {string[]} validationResult.warnings - Array of validation warnings
+ * @returns {string|null} error message or null if validation passed
+ */
+export const getValidationErrorMessage = (validationResult) => {
+  if (validationResult.isValid) {
+    return null;
+  }
+
+  if (validationResult.errors.length === 0) {
+    return MESSAGES.VALIDATION.ROADMAP_INCOMPLETE;
+  }
+
+  //  validation message 
+  return MESSAGES.VALIDATION.ROADMAP_VALIDATION_FAILED;
+}; 


### PR DESCRIPTION
- Added Zod schema validation for roadmap structure
- Handle markdown code block stripping from AI responses
- Support both string and number types for estimatedHours
- Added error messages and validation utilities

TODOS: I added version and technology verification. I am planning on implementing that if I get the chance. Otherwise, they may be removed in future PRs. 

- Added a toast message if verification fails

- Roadmap saves to db if verification goes through successfully.