### PR TITLE
fix: resolve JSON parsing error in dashboard

### DIFF
--- a/frontend/src/utils/dashboardUtils.js
+++ b/frontend/src/utils/dashboardUtils.js
@@ -1,4 +1,5 @@
 import { calculateOverallProgress } from '@/utils/roadmapUtils';
+import { getParsedRoadmap } from '@/utils/roadmapValidation';
 
 /**
  * Dashboard Statistics Calculator
@@ -62,7 +63,8 @@ export const calculateProjectStats = (projects) => {
 
   projects.forEach(project => {
     try {
-      const roadmapData = JSON.parse(project.content);
+      // Use the helper function that handles markdown code blocks
+      const roadmapData = getParsedRoadmap(project.content);
       if (roadmapData?.phases) {
         // Calculate project progress
         const projectProgress = calculateOverallProgress(roadmapData.phases);
@@ -115,7 +117,8 @@ export const calculateProjectStats = (projects) => {
  */
 export const calculateProjectCompletion = (project) => {
   try {
-    const roadmapData = JSON.parse(project.content);
+    // Use the helper function that handles markdown code blocks
+    const roadmapData = getParsedRoadmap(project.content);
     if (roadmapData?.phases) {
       return calculateOverallProgress(roadmapData.phases);
     }
@@ -138,7 +141,8 @@ export const calculateMilestoneStats = (projects) => {
 
   projects.forEach(project => {
     try {
-      const roadmapData = JSON.parse(project.content);
+      // Use the helper function that handles markdown code blocks
+      const roadmapData = getParsedRoadmap(project.content);
       if (roadmapData?.phases) {
         roadmapData.phases.forEach(phase => {
           if (phase.milestones) {


### PR DESCRIPTION
- Import getParsedRoadmap from roadmapValidation utils
- Replace direct JSON.parse() calls with getParsedRoadmap()
- Fixe issue where markdown code blocks (`json) were causing parsing errors

**Before**
<img width="1722" height="738" alt="new17" src="https://github.com/user-attachments/assets/c134d0e5-4777-46e2-aec8-8ec0e93dd44b" />


**After**
<img width="1711" height="923" alt="new18" src="https://github.com/user-attachments/assets/ad13a6b7-51ae-4cc7-8046-6290a4cbb586" />
