### PR TITLE
feat: disable generate button after chat initiation and optimize spacing

### DIFF
--- a/frontend/src/components/Chat/ChatContainer.jsx
+++ b/frontend/src/components/Chat/ChatContainer.jsx
@@ -16,7 +16,7 @@ const ChatContainer = ({ messages, loading, stage, sendMessage }) => {
   }, [messages]);
 
   return (
-    <div className="flex h-full flex-col rounded-lg border border-gray-200 bg-white pb-4">
+    <div className="flex h-full flex-col rounded-lg border border-gray-200 bg-white pb-2">
       <div className="flex-1 overflow-y-auto p-4">
         {messages.length === 0 ? (
           <div className="flex h-full items-center justify-center text-gray-500">
@@ -43,7 +43,7 @@ const ChatContainer = ({ messages, loading, stage, sendMessage }) => {
         <div ref={bottomRef} />
       </div>
 
-      <div className="px-4">
+      <div className="px-2">
         <ChatInput onSendMessage={handleSendMessage} disabled={loading || stage === 'initial'} />
       </div>
     </div>

--- a/frontend/src/hooks/useProjectForm.js
+++ b/frontend/src/hooks/useProjectForm.js
@@ -2,9 +2,10 @@ import { useCallback } from 'react';
 import useProjectDetail from '@/hooks/useProjectDetail';
 import { FORM_FIELDS } from '@/constants/projectOptions';
 import { hasRequiredFields, getFinalTimeline } from '@/utils/formValidation';
+import { CHAT_STAGES } from '@/constants/messages';
 
 // Hook for managing project form state and validation
-export const useProjectForm = (startChatWithDetails, chatLoading, fileLoading) => {
+export const useProjectForm = (startChatWithDetails, chatLoading, fileLoading, stage) => {
   // Initialize form with all project fields
   const { values, handleChange } = useProjectDetail({
     [FORM_FIELDS.TITLE]: '',
@@ -25,9 +26,11 @@ export const useProjectForm = (startChatWithDetails, chatLoading, fileLoading) =
   }, [values, startChatWithDetails]);
 
   // Checks if form is valid and not currently loading
+  // Also disables generate button once chat has been initiated
   const canGenerate = useCallback((processedFile) => {
-    return hasRequiredFields(values) && !chatLoading && !fileLoading;
-  }, [values, chatLoading, fileLoading]);
+    const isChatInitiated = stage !== CHAT_STAGES.INITIAL;
+    return hasRequiredFields(values) && !chatLoading && !fileLoading && !isChatInitiated;
+  }, [values, chatLoading, fileLoading, stage]);
 
   return {
     values,

--- a/frontend/src/pages/NewProjectChat/NewProjectChatPage.jsx
+++ b/frontend/src/pages/NewProjectChat/NewProjectChatPage.jsx
@@ -46,7 +46,8 @@ const NewProjectChatPage = () => {
   const { values, handleChange, handleGenerateRoadmap, canGenerate } = useProjectForm(
     startChatWithDetails, 
     chatLoading, 
-    fileLoading
+    fileLoading,
+    stage
   );
 
   const { saving, savedProjectId, handleSaveProject } = useProjectSave(messages, values);
@@ -151,14 +152,21 @@ const NewProjectChatPage = () => {
             </FormField>
 
             <div className="flex justify-center pt-4">
-              <Button
-                onClick={onGenerateClick}
-                disabled={!canGenerate(processedFile)}
-                size="md"
-                className="px-6 py-2"
-              >
-                {chatLoading ? MESSAGES.LOADING.GENERATING_ROADMAP : MESSAGES.ACTIONS.GENERATE_ROADMAP}
-              </Button>
+              <div className="text-center">
+                <Button
+                  onClick={onGenerateClick}
+                  disabled={!canGenerate(processedFile)}
+                  size="md"
+                  className="px-6 py-2"
+                >
+                  {chatLoading ? MESSAGES.LOADING.GENERATING_ROADMAP : MESSAGES.ACTIONS.GENERATE_ROADMAP}
+                </Button>
+                {stage !== CHAT_STAGES.INITIAL && (
+                  <p className="mt-2 text-sm text-gray-600">
+                    Use the chat to modify your roadmap
+                  </p>
+                )}
+              </div>
             </div>
           </div>
         </div>
@@ -183,7 +191,7 @@ const NewProjectChatPage = () => {
           
           {/* Project saving section - show when roadmap is generated */}
           {(stage === CHAT_STAGES.AWAITING_CONFIRMATION || stage === CHAT_STAGES.DONE) && (
-            <div className="border-t border-gray-200 p-4">
+            <div className="border-t border-gray-200 p-2">
               <div className="text-center">
                 <Button
                   onClick={handleSaveProject}


### PR DESCRIPTION
- Disable generate button once chat is initiated to prevent re-generation
- Add helpful message directing users to use chat for modifications


<img width="1361" height="929" alt="new20" src="https://github.com/user-attachments/assets/9a9d083f-f677-4c5f-82d2-f6a54922614a" />


<img width="630" height="308" alt="new21" src="https://github.com/user-attachments/assets/f4859d70-6056-4e3d-962a-2aed1e0fbd91" />
