### PR TITLE
fix: eliminate grey areas on NewProjectChat page sides

### DIFF
--- a/frontend/src/pages/NewProjectChat/NewProjectChatPage.jsx
+++ b/frontend/src/pages/NewProjectChat/NewProjectChatPage.jsx
@@ -228,15 +228,17 @@ const NewProjectChatPage = () => {
 
   // --- Responsive Layout ---
   return (
-    <div className="mx-auto min-h-screen max-w-7xl bg-gray-100 p-6 dark:bg-gray-800">
-      {isMobile ? (
-        <div className="flex flex-col gap-6">{mobileStep === 1 ? formSection : chatSection}</div>
-      ) : (
-        <div className="grid h-[calc(100vh-3rem)] grid-cols-1 gap-6 lg:grid-cols-2">
-          {formSection}
-          {chatSection}
-        </div>
-      )}
+    <div className="min-h-screen bg-gray-100 p-6 dark:bg-gray-900">
+      <div className="mx-auto max-w-7xl">
+        {isMobile ? (
+          <div className="flex flex-col gap-6">{mobileStep === 1 ? formSection : chatSection}</div>
+        ) : (
+          <div className="grid h-[calc(100vh-3rem)] grid-cols-1 gap-6 lg:grid-cols-2">
+            {formSection}
+            {chatSection}
+          </div>
+        )}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
- Restructure page layout to cover entire viewport width
- Move max-width constraint to inner container
- Ensure proper dark mode background coverage

Previously the background of this page was grey and was not matching the colors on the page when we toggle dark mode. You can see that from my last PR video. So i essentially moved the max-width constraint to inner container to allow page layout to cover the entire viewport width and ensure consistent color match on dark mode.

<img width="1725" height="953" alt="newnew" src="https://github.com/user-attachments/assets/ab5f7486-053d-46e5-a278-63eca42a41c2" />

