### PR TITLE
feat: add milestone creation functionality

### DIFF
--- a/frontend/src/components/Roadmap/CreateMilestoneModal.jsx
+++ b/frontend/src/components/Roadmap/CreateMilestoneModal.jsx
@@ -1,0 +1,195 @@
+import React, { useState, useEffect } from 'react';
+import { X, Save } from 'lucide-react';
+import { COLOR_CLASSES, COLOR_PATTERNS } from '@/constants/colors';
+
+/**
+ * CreateMilestoneModal - modal for creating new milestones
+ *
+ * COMPONENT:
+ * This modal provides a focused creation experience for milestones within phases.
+ * Simple form with fields for milestone creation.
+ *
+ * KEY FEATURES:
+ * - Responsive Design: Optimized for both desktop and mobile screens
+ * - Focused Creation: Dedicated space for milestone creation without distractions
+ * - Form Validation: Prevents saving empty titles
+
+ *
+ * USER INTERACTION FLOW:
+ * 1. User clicks "Add Milestone" → Modal opens with empty form
+ * 2. User enters title/timeline → Real-time validation
+ * 3. User clicks Save → Creates milestone, closes modal
+ * 4. User clicks Cancel/X → Discards changes, closes modal
+ *
+ * STATE MANAGEMENT:
+ * - Local state: form data, validation state
+ * - Props: modal open/close state, callbacks
+ *
+ * @param {Object} props - Component props
+ * @param {boolean} props.isOpen - Whether the modal is open
+ * @param {Function} props.onClose - Function to close the modal
+ * @param {Function} props.onSave - Callback to save milestone data
+ * @param {number} props.nextOrder - Next order number for the milestone
+ */
+const CreateMilestoneModal = ({ isOpen, onClose, onSave, nextOrder }) => {
+  const [formData, setFormData] = useState({ title: '', timeline: '' });
+  const [isValid, setIsValid] = useState(true);
+
+  // Initialize form data when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      setFormData({ title: '', timeline: '' });
+      setIsValid(true);
+    }
+  }, [isOpen]);
+
+  // Handle form data changes
+  const handleInputChange = (field, value) => {
+    const newData = { ...formData, [field]: value };
+    setFormData(newData);
+    setIsValid(newData.title.trim().length > 0);
+  };
+
+  // Handle save
+  const handleSave = () => {
+    if (!formData.title.trim()) {
+      setIsValid(false);
+      return;
+    }
+
+    const newMilestone = {
+      id: `milestone-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+      title: formData.title.trim(),
+      timeline: formData.timeline.trim() || `Milestone ${nextOrder}`,
+      order: nextOrder,
+      tasks: [],
+    };
+
+    onSave(newMilestone);
+    onClose();
+  };
+
+  // Handle cancel
+  const handleCancel = () => {
+    onClose();
+  };
+
+  // Handle keyboard shortcuts
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+      e.preventDefault();
+      handleSave();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      handleCancel();
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className={`${COLOR_PATTERNS.components.modal.overlay} z-50`} onClick={handleCancel}>
+      <div
+        className={`${COLOR_PATTERNS.components.modal.container} mx-4 flex max-h-[90vh] w-full max-w-lg flex-col overflow-hidden`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div
+          className={`border-b border-gray-200 p-4 dark:border-gray-600 ${COLOR_CLASSES.surface.modal} flex-shrink-0`}
+        >
+          <div className="flex items-center justify-between">
+            <h2 className={`text-lg font-semibold ${COLOR_CLASSES.text.heading}`}>
+              Add New Milestone
+            </h2>
+            <button
+              onClick={handleCancel}
+              className="rounded-full p-1 transition-colors duration-200 hover:bg-gray-100 focus:outline-none dark:hover:bg-gray-800"
+              aria-label="Close modal"
+            >
+              <X className="h-5 w-5 text-gray-600 dark:text-white" />
+            </button>
+          </div>
+        </div>
+
+        {/* Form */}
+        <div className={`p-4 ${COLOR_CLASSES.surface.modal} flex-1 overflow-y-auto`}>
+          <div className="space-y-4">
+            {/* Title Field */}
+            <div>
+              <label
+                htmlFor="milestone-title"
+                className={`mb-2 block text-sm font-medium ${COLOR_CLASSES.text.heading}`}
+              >
+                Milestone Title *
+              </label>
+              <textarea
+                id="milestone-title"
+                className={`w-full font-medium ${COLOR_CLASSES.text.heading} border bg-gray-100 dark:bg-gray-700 ${isValid ? 'border-gray-300 dark:border-gray-600' : 'border-red-500'} rounded px-3 py-2 focus:${COLOR_CLASSES.border.focus} max-h-[100px] min-h-[50px] resize-none outline-none transition-all duration-200 focus:ring-2 focus:ring-blue-200 dark:focus:ring-blue-800`}
+                value={formData.title}
+                onChange={(e) => handleInputChange('title', e.target.value)}
+                onKeyDown={handleKeyDown}
+                maxLength={100}
+                rows={1}
+                placeholder="Enter milestone title..."
+                autoFocus
+              />
+              {!isValid && (
+                <p className="mt-1 text-sm text-red-600 dark:text-red-400">
+                  Milestone title is required
+                </p>
+              )}
+            </div>
+
+            {/* Timeline Field */}
+            <div>
+              <label
+                htmlFor="milestone-timeline"
+                className={`mb-2 block text-sm font-medium ${COLOR_CLASSES.text.heading}`}
+              >
+                Timeline (Optional)
+              </label>
+              <input
+                id="milestone-timeline"
+                type="text"
+                className={`w-full ${COLOR_CLASSES.text.body} rounded border border-gray-300 bg-gray-100 px-3 py-2 text-sm leading-relaxed dark:border-gray-600 dark:bg-gray-700 focus:${COLOR_CLASSES.border.focus} outline-none transition-all duration-200 focus:ring-2 focus:ring-blue-200 dark:focus:ring-blue-800`}
+                value={formData.timeline}
+                onChange={(e) => handleInputChange('timeline', e.target.value)}
+                onKeyDown={handleKeyDown}
+                maxLength={50}
+                placeholder="e.g., Days 1-3, Week 1, Month 1"
+              />
+              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                Leave empty to auto-generate as "Milestone {nextOrder}"
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div
+          className={`border-t border-gray-200 p-4 dark:border-gray-600 ${COLOR_CLASSES.surface.modal} flex-shrink-0`}
+        >
+          <div className="flex justify-end gap-3">
+            <button
+              onClick={handleCancel}
+              className={`flex items-center space-x-1 rounded px-4 py-2 ${COLOR_PATTERNS.button.secondary} text-sm`}
+            >
+              <X className="h-4 w-4" />
+              <span>Cancel</span>
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={!isValid}
+              className={`flex items-center space-x-1 rounded px-4 py-2 ${COLOR_PATTERNS.button.primary} text-sm disabled:cursor-not-allowed disabled:bg-gray-300`}
+            >
+              <Save className="h-4 w-4" />
+              <span>Save</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CreateMilestoneModal;

--- a/frontend/src/components/Roadmap/PhaseModal.jsx
+++ b/frontend/src/components/Roadmap/PhaseModal.jsx
@@ -9,10 +9,11 @@ import {
   Edit2,
   Plus,
 } from 'lucide-react';
-import { COLOR_CLASSES, COLOR_PATTERNS } from '../../constants/colors';
+import { COLOR_CLASSES, COLOR_PATTERNS } from '@/constants/colors';
 import { TASK_STATUS } from '@/constants/roadmap';
 import { calculateMilestoneProgress } from '@/utils/roadmapUtils';
 import EditTaskModal from './EditTaskModal';
+import CreateMilestoneModal from './CreateMilestoneModal';
 
 /**
  * PhaseModal - Responsive modal for displaying phase details, milestones, and tasks with modal editing
@@ -63,6 +64,7 @@ const PhaseModal = ({ open, onClose, phase, onTaskUpdate }) => {
   const [editingTask, setEditingTask] = useState(null);
   const [isAddTaskModalOpen, setIsAddTaskModalOpen] = useState(false);
   const [addingToMilestone, setAddingToMilestone] = useState(null);
+  const [isAddMilestoneModalOpen, setIsAddMilestoneModalOpen] = useState(false);
 
   if (!open || !phase) return null;
 
@@ -142,6 +144,32 @@ const PhaseModal = ({ open, onClose, phase, onTaskUpdate }) => {
       onTaskUpdate(phase.id, addingToMilestone, null, newTask, 'add');
     }
     handleCloseAddTaskModal();
+  };
+
+  /**
+   * Start adding a new milestone to the phase
+   */
+  const handleStartAddMilestone = () => {
+    setIsAddMilestoneModalOpen(true);
+  };
+
+  /**
+   * Close add milestone modal
+   */
+  const handleCloseAddMilestoneModal = () => {
+    setIsAddMilestoneModalOpen(false);
+  };
+
+  /**
+   * Save new milestone
+   * @param {Object} newMilestone - The new milestone data with generated ID
+   */
+  const handleSaveAddMilestone = (newMilestone) => {
+    if (onTaskUpdate) {
+      // Pass the new milestone to the parent for insertion
+      onTaskUpdate(phase.id, null, null, newMilestone, 'addMilestone');
+    }
+    handleCloseAddMilestoneModal();
   };
 
   return (
@@ -347,6 +375,18 @@ const PhaseModal = ({ open, onClose, phase, onTaskUpdate }) => {
               No milestones available for this phase.
             </div>
           )}
+
+          {/* Add Milestone Button */}
+          <div className="mt-6 flex justify-center">
+            <button
+              onClick={handleStartAddMilestone}
+              className={`flex items-center space-x-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors duration-200 ${COLOR_PATTERNS.button.primary} hover:bg-blue-600 dark:hover:bg-blue-500`}
+              aria-label="Add new milestone"
+            >
+              <Plus className="h-4 w-4" />
+              <span>Add Milestone</span>
+            </button>
+          </div>
         </div>
       </div>
 
@@ -364,6 +404,14 @@ const PhaseModal = ({ open, onClose, phase, onTaskUpdate }) => {
         onClose={handleCloseAddTaskModal}
         task={null}
         onSave={handleSaveAddTask}
+      />
+
+      {/* Add Milestone Modal */}
+      <CreateMilestoneModal
+        isOpen={isAddMilestoneModalOpen}
+        onClose={handleCloseAddMilestoneModal}
+        onSave={handleSaveAddMilestone}
+        nextOrder={phase.milestones ? phase.milestones.length + 1 : 1}
       />
     </div>
   );

--- a/frontend/src/pages/ProjectDetail/ProjectDetailPage.jsx
+++ b/frontend/src/pages/ProjectDetail/ProjectDetailPage.jsx
@@ -115,51 +115,58 @@ const ProjectDetailPage = () => {
   /**
    * Handler to update task status and content from modal
    * Supports both legacy format (status string) and new format (object with title, description, status)
-   * Also supports adding new tasks when action is 'add'
+   * Also supports adding new tasks when action is 'add' and new milestones when action is 'addMilestone'
    * @param {string} phaseId - The phase ID containing the task
    * @param {string} milestoneId - The milestone ID containing the task
    * @param {string} taskId - The task ID to update (null for new tasks)
-   * @param {string|Object} updates - Either status string (legacy) or object with title, description, status, or new task object
-   * @param {string} action - 'update' (default) or 'add' for new tasks
+   * @param {string|Object} updates - Either status string (legacy) or object with title, description, status, or new task/milestone object
+   * @param {string} action - 'update' (default), 'add' for new tasks, or 'addMilestone' for new milestones
    */
   const handleTaskUpdate = (phaseId, milestoneId, taskId, updates, action = 'update') => {
     setRoadmapData((prevRoadmap) => {
       const newPhases = prevRoadmap.phases.map((phase) => {
         if (phase.id === phaseId) {
-          const newMilestones = phase.milestones.map((milestone) => {
-            if (milestone.id === milestoneId) {
-              if (action === 'add') {
-                // Add new task to the milestone
-                const newTask = updates; // updates is the complete new task object
-                const newTasks = [...milestone.tasks, newTask];
-                return { ...milestone, tasks: newTasks };
-              } else {
-                // Update existing task
-                const newTasks = milestone.tasks.map((task) => {
-                  if (task.id === taskId) {
-                    // Handle both our init and new format (object)
-                    if (typeof updates === 'string') {
-                      // Legacy format: just status
-                      return { ...task, status: updates };
-                    } else {
-                      // New format: object with title, description, status, and resources
-                      return {
-                        ...task,
-                        title: updates.title || task.title,
-                        description: updates.description || task.description,
-                        status: updates.status || task.status,
-                        resources: updates.resources || task.resources || [],
-                      };
+          if (action === 'addMilestone') {
+            // Add new milestone to the phase
+            const newMilestone = updates; // updates is the complete new milestone object
+            const newMilestones = [...phase.milestones, newMilestone];
+            return { ...phase, milestones: newMilestones };
+          } else {
+            const newMilestones = phase.milestones.map((milestone) => {
+              if (milestone.id === milestoneId) {
+                if (action === 'add') {
+                  // Add new task to the milestone
+                  const newTask = updates; // updates is the complete new task object
+                  const newTasks = [...milestone.tasks, newTask];
+                  return { ...milestone, tasks: newTasks };
+                } else {
+                  // Update existing task
+                  const newTasks = milestone.tasks.map((task) => {
+                    if (task.id === taskId) {
+                      // Handle both our init and new format (object)
+                      if (typeof updates === 'string') {
+                        // Legacy format: just status
+                        return { ...task, status: updates };
+                      } else {
+                        // New format: object with title, description, status, and resources
+                        return {
+                          ...task,
+                          title: updates.title || task.title,
+                          description: updates.description || task.description,
+                          status: updates.status || task.status,
+                          resources: updates.resources || task.resources || [],
+                        };
+                      }
                     }
-                  }
-                  return task;
-                });
-                return { ...milestone, tasks: newTasks };
+                    return task;
+                  });
+                  return { ...milestone, tasks: newTasks };
+                }
               }
-            }
-            return milestone;
-          });
-          return { ...phase, milestones: newMilestones };
+              return milestone;
+            });
+            return { ...phase, milestones: newMilestones };
+          }
         }
         return phase;
       });


### PR DESCRIPTION
**Features**
-Added CreateMilestoneModal component for creating new milestones
- Integrate milestone creation into PhaseModal
- Update ProjectDetailPage to handle milestone additions

**How it works**
User clicks on add milestone button below the phase modal. A modal pops up for the user to fill in the milestone title and an optional timeline. The user can either enter timeline: like 10 days or months to display on their milestone or leave it black, in that case, I auto generate the timeline with the next milestone number. For instance, if we already had two milestones, the timeline for the next milestone will be milestone 3. This is just an initial implementation. In the future, I will come up with a proper way of handling this. 

**Before**
<img width="1723" height="949" alt="newn" src="https://github.com/user-attachments/assets/206efab0-f3b8-4509-bc59-0c57ab12da43" />


**After**
<img width="1715" height="905" alt="addmiletsone" src="https://github.com/user-attachments/assets/c6ef6a25-50b9-4f93-835d-e83e6859c474" />


**Milestone Modal**
<img width="1166" height="726" alt="milemodal" src="https://github.com/user-attachments/assets/9bd23b72-cb12-4c4b-83ac-850505b10c9c" />


**Video Description**
<div>
    <a href="https://www.loom.com/share/903c7a64cb9e4c06b59e63991737ad23">
      <p>TC Roadmap Prioritization Algorithm Documentation - Google Docs - 17 July 2025 - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/903c7a64cb9e4c06b59e63991737ad23">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/903c7a64cb9e4c06b59e63991737ad23-3a066edcbac58b78-full-play.gif">
    </a>
  </div>
