### PR TITLE
fix: address PR feedback 

### DIFF
--- a/frontend/src/components/Roadmap/EditTaskModal.jsx
+++ b/frontend/src/components/Roadmap/EditTaskModal.jsx
@@ -71,6 +71,7 @@ const EditTaskModal = ({ isOpen, onClose, task, onSave }) => {
           resources: Array.isArray(task.resources) ? task.resources : [],
         });
         initialize(task.resources || []);
+        setIsValid(true); // Valid because task has existing data
       } else {
         // Create mode: start with empty form
         setFormData({
@@ -79,8 +80,8 @@ const EditTaskModal = ({ isOpen, onClose, task, onSave }) => {
           resources: [],
         });
         initialize([]);
+        setIsValid(false); // Invalid because form is empty
       }
-      setIsValid(true);
       setIsResourcesExpanded(false);
     }
   }, [isOpen, task]);

--- a/frontend/src/constants/cache.js
+++ b/frontend/src/constants/cache.js
@@ -39,16 +39,16 @@ export const CACHE_CONFIG = {
 
 // Constants for query keys
 export const QUERY_KEYS = {
-  AI_RESPONSES: 'ai-response',
-  USER_PROJECTS: 'user-projects',
+  AI_RESPONSES: 'aiResponse',
+  USER_PROJECTS: 'userProjects',
   PROJECT_DETAILS: 'project',
-  USER_PROFILE: 'user-profile',
-  STATIC_CONTENT: 'static-content',
+  USER_PROFILE: 'userProfile',
+  STATIC_CONTENT: 'staticContent',
 };
 
 // Constants for storage keys
 export const STORAGE_KEYS = {
-  ROADMAP_CACHE: 'roadmap-cache',
+  ROADMAP_CACHE: 'roadmapCache',
   CHAT_MESSAGES: 'chatMessages',
   CHAT_STAGE: 'chatStage',
   PROJECT_TITLE: 'projectTitle',

--- a/frontend/src/pages/ProjectDetail/ProjectDetailPage.jsx
+++ b/frontend/src/pages/ProjectDetail/ProjectDetailPage.jsx
@@ -272,20 +272,14 @@ const ProjectDetailPage = () => {
                   // Update existing task
                   const newTasks = milestone.tasks.map((task) => {
                     if (task.id === taskId) {
-                      // Handle both our init and new format (object)
-                      if (typeof updates === 'string') {
-                        // Legacy format: just status
-                        return { ...task, status: updates };
-                      } else {
-                        // New format: object with title, description, status, and resources
-                        return {
-                          ...task,
-                          title: updates.title || task.title,
-                          description: updates.description || task.description,
-                          status: updates.status || task.status,
-                          resources: updates.resources || task.resources || [],
-                        };
-                      }
+                      // Update task with new format: object with title, description, status, and resources
+                      return {
+                        ...task,
+                        title: updates.title || task.title,
+                        description: updates.description || task.description,
+                        status: updates.status || task.status,
+                        resources: updates.resources || task.resources || [],
+                      };
                     }
                     return task;
                   });

--- a/frontend/src/utils/formValidation.js
+++ b/frontend/src/utils/formValidation.js
@@ -73,7 +73,6 @@ export const validateResources = (resources) => {
   const errors = {};
   let hasErrors = false;
 
-
   resources.forEach((resource, index) => {
     const resourceErrors = validateResource(resource);
     if (Object.keys(resourceErrors).length > 0) {


### PR DESCRIPTION
**Fixed**
- Renames cache keys
- Removed extra white space
- Removed legacy format when updating the project task

I have addressed the feedbacks from the Previous PRs regarding the cache key naming, whitespace, form validation in this PR. I chose camelcase instead of the hyphenated naming/both.  This has ensured the consistencies in the naming as recommended in the feedback from the previous PRs. 

I have also removed the legacy format as we are now using the new format: object with title, description, status, and resources instead of the legacy format which had only the status.  I left both initially to make sure my code doesn't break and still functions as it should, but after commenting the legacy format out and running the application, the new format works just fine. Therefore I have removed the legacy format. 

TODO: Improve the milestone UX, by adding a toast notification when a user rearranges the milestone. 
