### PR TITLE
feat: added milestone reordering UX improvements with toast notification

### DIFF
--- a/frontend/src/components/Roadmap/PhaseModal.jsx
+++ b/frontend/src/components/Roadmap/PhaseModal.jsx
@@ -14,8 +14,11 @@ import {
 } from 'lucide-react';
 import { COLOR_CLASSES, COLOR_PATTERNS } from '@/constants/colors';
 import { TASK_STATUS } from '@/constants/roadmap';
+import { MESSAGES } from '@/constants/messages';
 import { calculateMilestoneProgress } from '@/utils/roadmapUtils';
 import confirmAction from '@/utils/confirmAction';
+import { showSuccessToast } from '@/utils/toastUtils';
+import { getReorderButtonState, getButtonClasses, getDisabledButtonClasses } from '@/utils/buttonUtils';
 import EditTaskModal from './EditTaskModal';
 import CreateMilestoneModal from './CreateMilestoneModal';
 
@@ -241,6 +244,7 @@ const PhaseModal = ({ open, onClose, phase, onTaskUpdate, onMilestoneReorder }) 
   const handleMoveMilestoneUp = (milestoneId) => {
     if (onMilestoneReorder) {
       onMilestoneReorder(phase.id, milestoneId, 'up');
+      showSuccessToast(MESSAGES.SUCCESS.MILESTONE_MOVED_UP);
     }
   };
 
@@ -251,6 +255,7 @@ const PhaseModal = ({ open, onClose, phase, onTaskUpdate, onMilestoneReorder }) 
   const handleMoveMilestoneDown = (milestoneId) => {
     if (onMilestoneReorder) {
       onMilestoneReorder(phase.id, milestoneId, 'down');
+      showSuccessToast(MESSAGES.SUCCESS.MILESTONE_MOVED_DOWN);
     }
   };
 
@@ -283,7 +288,10 @@ const PhaseModal = ({ open, onClose, phase, onTaskUpdate, onMilestoneReorder }) 
         <div className={`flex-1 overflow-y-auto p-6 ${COLOR_CLASSES.surface.modal}`}>
           {phase.milestones && phase.milestones.length > 0 ? (
             <div className="space-y-4">
-              {phase.milestones.map((milestone) => (
+              {phase.milestones.map((milestone, index) => {
+                const { isFirst, isLast } = getReorderButtonState(index, phase.milestones.length);
+                
+                return (
                 <div
                   key={milestone.id}
                   className="rounded-lg border border-gray-200 bg-gray-50 shadow-lg dark:border-gray-500 dark:bg-gray-800"
@@ -327,7 +335,12 @@ const PhaseModal = ({ open, onClose, phase, onTaskUpdate, onMilestoneReorder }) 
                             e.stopPropagation();
                             handleMoveMilestoneUp(milestone.id);
                           }}
-                          className={`rounded p-1 ${COLOR_CLASSES.surface.cardHover} transition-colors ${COLOR_CLASSES.action.reorder.hover}`}
+                          disabled={isFirst}
+                          className={`rounded p-1 transition-colors ${getButtonClasses(
+                            isFirst,
+                            `${COLOR_CLASSES.surface.cardHover} ${COLOR_CLASSES.action.reorder.hover}`,
+                            getDisabledButtonClasses()
+                          )}`}
                           aria-label="Move milestone up"
                         >
                           <ArrowUp className={`h-4 w-4 ${COLOR_CLASSES.action.reorder.icon}`} />
@@ -337,7 +350,12 @@ const PhaseModal = ({ open, onClose, phase, onTaskUpdate, onMilestoneReorder }) 
                             e.stopPropagation();
                             handleMoveMilestoneDown(milestone.id);
                           }}
-                          className={`rounded p-1 ${COLOR_CLASSES.surface.cardHover} transition-colors ${COLOR_CLASSES.action.reorder.hover}`}
+                          disabled={isLast}
+                          className={`rounded p-1 transition-colors ${getButtonClasses(
+                            isLast,
+                            `${COLOR_CLASSES.surface.cardHover} ${COLOR_CLASSES.action.reorder.hover}`,
+                            getDisabledButtonClasses()
+                          )}`}
                           aria-label="Move milestone down"
                         >
                           <ArrowDown className={`h-4 w-4 ${COLOR_CLASSES.action.reorder.icon}`} />
@@ -499,7 +517,8 @@ const PhaseModal = ({ open, onClose, phase, onTaskUpdate, onMilestoneReorder }) 
                     </div>
                   )}
                 </div>
-              ))}
+              );
+            })}
             </div>
           ) : (
             <div className={`py-8 text-center ${COLOR_CLASSES.text.body}`}>

--- a/frontend/src/constants/messages.js
+++ b/frontend/src/constants/messages.js
@@ -9,6 +9,8 @@ export const MESSAGES = {
   SUCCESS: {
     PROJECT_SAVED: 'Project saved successfully!',
     FILE_PROCESSED: '✓ Document processed successfully!',
+    MILESTONE_MOVED_UP: 'Milestone moved up successfully',
+    MILESTONE_MOVED_DOWN: 'Milestone moved down successfully',
   },
   ERROR: {
     PROJECT_SAVE_FAILED: 'Failed to save project. Please try again.',

--- a/frontend/src/pages/NewProjectChat/NewProjectChatPage.jsx
+++ b/frontend/src/pages/NewProjectChat/NewProjectChatPage.jsx
@@ -36,8 +36,10 @@ import {
   FORM_FIELDS,
 } from '@/constants/projectOptions';
 import LoadingSpinner from '@/components/Loading/LoadingSpinner';
-import { CheckCircle } from 'lucide-react';
+import { CheckCircle, Plus } from 'lucide-react';
 import useIsMobile from '@/hooks/useIsMobile';
+import resetNewProjectState from '@/utils/resetNewProjectState';
+import confirmAction from '@/utils/confirmAction';
 
 const NewProjectChatPage = () => {
   const navigate = useNavigate();
@@ -89,6 +91,23 @@ const NewProjectChatPage = () => {
     } catch (error) {
       //not advance to chat step on mobile if there's an error
     }
+  };
+
+  const handleNewProject = () => {
+    const shouldProceed = confirmAction(
+      'Are you sure you want to start over? This will clear all your current progress.'
+    );
+
+    if (!shouldProceed) {
+      return; // User cancelled, nothing happens
+    }
+
+    // Reset state
+    resetNewProjectState();
+    clearFile();
+    resetChat();
+    resetForm();
+    setMobileStep(1);
   };
 
   // --- Form Section ---
@@ -215,10 +234,19 @@ const NewProjectChatPage = () => {
         />
       </div>
       {(stage === CHAT_STAGES.AWAITING_CONFIRMATION || stage === CHAT_STAGES.DONE) && (
-        <div className="border-t border-gray-200 p-2 dark:border-gray-700">
-          <div className="text-center">
+        <div className="border-t border-gray-200 p-4 dark:border-gray-700">
+          <div className="flex justify-center space-x-4">
             <Button onClick={handleSaveProject} disabled={saving} size="md" className="px-6 py-2">
               {saving ? MESSAGES.LOADING.SAVING_PROJECT : MESSAGES.ACTIONS.SAVE_PROJECT}
+            </Button>
+            <Button 
+              onClick={handleNewProject} 
+              size="md" 
+              variant="secondary"
+              className="px-6 py-2 flex items-center space-x-2"
+            >
+              <Plus className="h-4 w-4" />
+              <span>New Project</span>
             </Button>
           </div>
         </div>

--- a/frontend/src/utils/buttonUtils.js
+++ b/frontend/src/utils/buttonUtils.js
@@ -1,0 +1,50 @@
+/**
+ * Button utility functions
+ * 
+/**
+ * Get button classes based on disabled state
+ * 
+ * This function returns CSS classes:
+ * - If isDisabled is true: returns disabledClasses
+ * - If isDisabled is false: returns baseClasses
+ * 
+ * @param {boolean} isDisabled - Whether the button should be disabled
+ * @param {string} baseClasses - CSS classes for enabled state 
+ * @param {string} disabledClasses - CSS classes for disabled state 
+ * @returns {string} Combined CSS classes based on disabled state
+ * 
+ */
+export const getButtonClasses = (isDisabled, baseClasses, disabledClasses) => {
+  return isDisabled ? disabledClasses : baseClasses;
+};
+
+/**
+ * Get reorder button state for a list item
+ *
+ * This function calculates the position-based states for reorder buttons:
+ * - canMoveUp: true if item can move up (not first)
+ * - canMoveDown: true if item can move down (not last)
+ * - isFirst: true if item is at position 0
+ * - isLast: true if item is at the last position
+ *
+ * @param {number} currentIndex - Current position in the list (0-based)
+ * @param {number} totalItems - Total number of items in the list
+ * @returns {Object} Object containing reorder button states
+ */
+export const getReorderButtonState = (currentIndex, totalItems) => {
+  return {
+    canMoveUp: currentIndex > 0, // Can move up if not at position 0
+    canMoveDown: currentIndex < totalItems - 1, // Can move down if not at last position
+    isFirst: currentIndex === 0, // Is first if at position 0
+    isLast: currentIndex === totalItems - 1, // Is last if at last position
+  };
+};
+
+/**
+ * Get disabled button classes with consistent styling
+ *
+ * @returns {string} CSS classes for disabled buttons
+ */
+export const getDisabledButtonClasses = () => {
+  return 'cursor-not-allowed opacity-50';
+};


### PR DESCRIPTION
**Features**
- Disabled the up/down arrow button on the milestone[first/last]
        - On the first milestone, the move up button is disabled to prevent the user from moving the milestone further up instead of handling it at the backend. Likewise, the move down arrow button on the last milestone is also disabled to prevent moving the milestone further down. This will improve the user experience when reordering their milestones. 
     
- Added a toast notification when user successfully moves a milestone up/down
          - How it works: 
                - When a user successfully moves a milestone up or down, the user gets a toast notification showing that a milestone have been successfully moved. 

TODO: Add a new-project button close to the save button on the new-project-page per Shelly's PR feedback last week. 

**Video Description**
<div>
    <a href="https://www.loom.com/share/5cd2e72846f142228ae3a01fda92ee02">
      <p>TC Roadmap Prioritization Algorithm Documentation - Google Docs - 22 July 2025 - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/5cd2e72846f142228ae3a01fda92ee02">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/5cd2e72846f142228ae3a01fda92ee02-df72f835744a6f8e-full-play.gif">
    </a>
  </div>