### PR TITLE
feat: added an extra new-project button on the New Project page to improve user experience

### DIFF
--- a/frontend/src/pages/NewProjectChat/NewProjectChatPage.jsx
+++ b/frontend/src/pages/NewProjectChat/NewProjectChatPage.jsx
@@ -36,8 +36,10 @@ import {
   FORM_FIELDS,
 } from '@/constants/projectOptions';
 import LoadingSpinner from '@/components/Loading/LoadingSpinner';
-import { CheckCircle } from 'lucide-react';
+import { CheckCircle, Plus } from 'lucide-react';
 import useIsMobile from '@/hooks/useIsMobile';
+import resetNewProjectState from '@/utils/resetNewProjectState';
+import confirmAction from '@/utils/confirmAction';
 
 const NewProjectChatPage = () => {
   const navigate = useNavigate();
@@ -89,6 +91,23 @@ const NewProjectChatPage = () => {
     } catch (error) {
       //not advance to chat step on mobile if there's an error
     }
+  };
+
+  const handleNewProject = () => {
+    const shouldProceed = confirmAction(
+      'Are you sure you want to start over? This will clear all your current progress.'
+    );
+
+    if (!shouldProceed) {
+      return; // User cancelled, nothing happens
+    }
+
+    // Reset state
+    resetNewProjectState();
+    clearFile();
+    resetChat();
+    resetForm();
+    setMobileStep(1);
   };
 
   // --- Form Section ---
@@ -215,10 +234,19 @@ const NewProjectChatPage = () => {
         />
       </div>
       {(stage === CHAT_STAGES.AWAITING_CONFIRMATION || stage === CHAT_STAGES.DONE) && (
-        <div className="border-t border-gray-200 p-2 dark:border-gray-700">
-          <div className="text-center">
+        <div className="border-t border-gray-200 p-4 dark:border-gray-700">
+          <div className="flex justify-center space-x-4">
             <Button onClick={handleSaveProject} disabled={saving} size="md" className="px-6 py-2">
               {saving ? MESSAGES.LOADING.SAVING_PROJECT : MESSAGES.ACTIONS.SAVE_PROJECT}
+            </Button>
+            <Button 
+              onClick={handleNewProject} 
+              size="md" 
+              variant="secondary"
+              className="px-6 py-2 flex items-center space-x-2"
+            >
+              <Plus className="h-4 w-4" />
+              <span>New Project</span>
             </Button>
           </div>
         </div>


### PR DESCRIPTION
**Feature PR-feedback**
- Added a new-project button to the new-project-page to improve user experience

The new-project button have been placed closed to the save button when the user input get send to the AI. This will show up close to the save button, to allow users to either save their project or start to create a new project. This saves time, allowing users to quickly start creating a new project instead of navigating to the header (navbar) to locate the create-new/ new-project button to create a new project. 

The new-project button uses the existing confirmation dialog and same code as in the navbar, the only new changes added is adding the button close to where it is going to be easily accessible and integrating it existing functionality. 

**Before**
<img width="1361" height="929" alt="new20" src="https://github.com/user-attachments/assets/a65833d1-a581-45bc-8ba3-72ee7dd6eb9f" />

**After**
<img width="1370" height="942" alt="newP" src="https://github.com/user-attachments/assets/3d6f0798-1f9f-4461-ac72-05a3e94a8e23" />

**Video Description**
<div>
    <a href="https://www.loom.com/share/5c4975bd5f064343afdfa4af095b3e7e">
      <p>TC Roadmap Prioritization Algorithm Documentation - Google Docs - 22 July 2025 - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/5c4975bd5f064343afdfa4af095b3e7e">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/5c4975bd5f064343afdfa4af095b3e7e-b6ff84410c5df80a-full-play.gif">
    </a>
  </div>