### PR TITLE
feat: added phase title editing functionality

### DIFF
--- a/frontend/src/components/Roadmap/EditPhaseModal.jsx
+++ b/frontend/src/components/Roadmap/EditPhaseModal.jsx
@@ -1,0 +1,165 @@
+import React, { useState, useEffect } from 'react';
+import { X, Save } from 'lucide-react';
+import { COLOR_CLASSES, COLOR_PATTERNS } from '@/constants/colors';
+
+/**
+ * Modal for editing phase titles
+ *
+ * HOW IT WORKS:
+ *
+ * 1. FORM STATE: Manages local form state with title input and validation status.
+ *    - formData: Current form values (title)
+ *    - isValid: Real-time validation state for immediate user feedback
+ *
+ * 2. INITIALIZATION: When modal opens, pre-populates form with existing phase data
+ *    using useEffect to ensure form reflects current phase title.
+ *
+ * 3. VALIDATION: Real-time validation ensures title is not empty before allowing save.
+ *    Shows error message and disables save button if validation fails.
+ *
+ * 4. SAVE HANDLING: Sends only the updated title back to parent component for processing.
+ *
+ * 5. KEYBOARD SHORTCUTS: Supports Ctrl+Enter to save and Escape to cancel for better UX.
+ *
+ * @param {Object} props - Component props
+ * @param {boolean} props.isOpen - Whether the modal is open
+ * @param {Function} props.onClose - Function to close the modal
+ * @param {Object} props.phase - Phase data to edit
+ * @param {Function} props.onSave - Callback to save phase changes
+ */
+const EditPhaseModal = ({ isOpen, onClose, phase, onSave }) => {
+  const [formData, setFormData] = useState({ title: '' });
+  const [isValid, setIsValid] = useState(true);
+
+  // Initialize form data when modal opens
+  useEffect(() => {
+    if (isOpen && phase) {
+      setFormData({
+        title: phase.title || '',
+      });
+      setIsValid(true);
+    }
+  }, [isOpen, phase]);
+
+  // Handle form data changes
+  const handleInputChange = (field, value) => {
+    const newData = { ...formData, [field]: value };
+    setFormData(newData);
+    setIsValid(newData.title.trim().length > 0);
+  };
+
+  // Handle save
+  const handleSave = () => {
+    if (!formData.title.trim()) {
+      setIsValid(false);
+      return;
+    }
+
+    onSave({
+      title: formData.title.trim(),
+    });
+    onClose();
+  };
+
+  // Handle cancel
+  const handleCancel = () => {
+    onClose();
+  };
+
+  // Handle keyboard shortcuts
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+      e.preventDefault();
+      handleSave();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      handleCancel();
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className={`${COLOR_PATTERNS.components.modal.overlay} z-50`} onClick={handleCancel}>
+      <div
+        className={`${COLOR_PATTERNS.components.modal.container} mx-4 flex max-h-[90vh] w-full max-w-lg flex-col overflow-hidden`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div
+          className={`border-b border-gray-200 p-4 dark:border-gray-600 ${COLOR_CLASSES.surface.modal} flex-shrink-0`}
+        >
+          <div className="flex items-center justify-between">
+            <h2 className={`text-lg font-semibold ${COLOR_CLASSES.text.heading}`}>Edit Phase</h2>
+            <button
+              onClick={handleCancel}
+              className="rounded-full p-1 transition-colors duration-200 hover:bg-gray-100 focus:outline-none dark:hover:bg-gray-800"
+              aria-label="Close modal"
+            >
+              <X className="h-5 w-5 text-gray-600 dark:text-white" />
+            </button>
+          </div>
+        </div>
+
+        {/* Form */}
+        <div className={`p-4 ${COLOR_CLASSES.surface.modal} flex-1 overflow-y-auto`}>
+          <div className="space-y-4">
+            {/* Title Field */}
+            <div>
+              <label
+                htmlFor="phase-title"
+                className={`mb-2 block text-sm font-medium ${COLOR_CLASSES.text.heading}`}
+              >
+                Phase Title *
+              </label>
+              <textarea
+                id="phase-title"
+                className={`w-full font-medium ${COLOR_CLASSES.text.heading} border bg-gray-100 dark:bg-gray-700 ${isValid ? 'border-gray-300 dark:border-gray-600' : 'border-red-500'} rounded px-3 py-2 focus:${COLOR_CLASSES.border.focus} max-h-[100px] min-h-[50px] resize-none outline-none transition-all duration-200 focus:ring-2 focus:ring-blue-200 dark:focus:ring-blue-800`}
+                value={formData.title}
+                onChange={(e) => handleInputChange('title', e.target.value)}
+                onKeyDown={handleKeyDown}
+                maxLength={100}
+                rows={1}
+                placeholder="Enter phase title..."
+                autoFocus
+              />
+              {!isValid && (
+                <p className="mt-1 text-sm text-red-600 dark:text-red-400">
+                  Phase title is required
+                </p>
+              )}
+              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                {formData.title.length}/100 characters
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div
+          className={`border-t border-gray-200 p-4 dark:border-gray-600 ${COLOR_CLASSES.surface.modal} flex-shrink-0`}
+        >
+          <div className="flex justify-end gap-3">
+            <button
+              onClick={handleCancel}
+              className={`flex items-center space-x-1 rounded px-4 py-2 ${COLOR_PATTERNS.button.secondary} text-sm`}
+            >
+              <X className="h-4 w-4" />
+              <span>Cancel</span>
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={!isValid}
+              className={`flex items-center space-x-1 rounded px-4 py-2 ${COLOR_PATTERNS.button.primary} text-sm disabled:cursor-not-allowed disabled:bg-gray-300`}
+            >
+              <Save className="h-4 w-4" />
+              <span>Save</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EditPhaseModal;

--- a/frontend/src/components/Roadmap/PhaseCardNew.jsx
+++ b/frontend/src/components/Roadmap/PhaseCardNew.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Calendar, Clock, CheckCircle } from 'lucide-react';
+import { Calendar, Clock, CheckCircle, Edit2 } from 'lucide-react';
 import { calculatePhaseProgress } from '@/utils/roadmapUtils';
 import { TASK_STATUS } from '@/constants/roadmap';
 import { COLOR_CLASSES, COLOR_PATTERNS } from '@/constants/colors';
@@ -33,8 +33,9 @@ import { getPhaseColor } from '@/utils/roadmapUtils';
  * @param {Array} props.phase.milestones[].tasks - Array of task objects
  * @param {string} props.phase.milestones[].tasks[].status - Task status ('pending', 'completed', etc.)
  * @param {Function} [props.onClick] - Optional click handler for opening modal
+ * @param {Function} [props.onEdit] - Optional edit handler for editing phase title
  */
-const PhaseCardNew = ({ phase, onClick }) => {
+const PhaseCardNew = ({ phase, onClick, onEdit }) => {
   // Calculate phase progress percentage (0-100)
   const progress = calculatePhaseProgress(phase);
 
@@ -66,18 +67,30 @@ const PhaseCardNew = ({ phase, onClick }) => {
       className={`${COLOR_PATTERNS.landing.card} border-l-4 ${phaseColorClasses} cursor-pointer`}
       onClick={onClick}
     >
-      <div className="p-6">
+      <div className="px-2 py-4">
         {/* Header */}
-        <div className="mb-4 flex items-start justify-between">
+        <div className="mb-3 flex items-start justify-between">
           <div className="min-w-0 flex-1">
-            <h3 className={`text-lg font-semibold ${COLOR_CLASSES.text.heading} truncate`}>
+            <h3 className={`text-lg font-semibold ${COLOR_CLASSES.text.heading} truncate text-left`}>
               Phase {phase.order}: {phase.title}
             </h3>
           </div>
+          {onEdit && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onEdit(phase);
+              }}
+              className={`ml-2 rounded p-0.5 ${COLOR_CLASSES.surface.cardHover} transition-colors ${COLOR_CLASSES.action.edit.hover}`}
+              aria-label="Edit phase title"
+            >
+              <Edit2 className={`h-3 w-3 ${COLOR_CLASSES.action.edit.icon}`} />
+            </button>
+          )}
         </div>
 
         {/* Progress */}
-        <div className="mb-4">
+        <div className="mb-3">
           <div className="mb-2 flex items-center justify-between">
             <span className={`text-sm font-medium ${COLOR_CLASSES.text.body}`}>Progress</span>
             <span className={`text-sm font-semibold ${COLOR_CLASSES.text.heading}`}>

--- a/frontend/src/constants/messages.js
+++ b/frontend/src/constants/messages.js
@@ -11,6 +11,7 @@ export const MESSAGES = {
     FILE_PROCESSED: '✓ Document processed successfully!',
     MILESTONE_MOVED_UP: 'Milestone moved up successfully',
     MILESTONE_MOVED_DOWN: 'Milestone moved down successfully',
+    PHASE_UPDATED: 'Phase updated successfully',
   },
   ERROR: {
     PROJECT_SAVE_FAILED: 'Failed to save project. Please try again.',


### PR DESCRIPTION
**Features**
- Added EditPhaseModal component for editing phase titles
- Add edit button to PhaseCardNew component with proper styling
- Integrate phase editing with ProjectDetailPage
- Add keyboard shortcuts (Ctrl+Enter to save, Escape to cancel)
- Add success message for phase updates

**how it works:**
User clicks on the edit icon on the phase card, it opens a modal for the user to edit the phase title. The phase number is already calculated based on the order/position of the phase so in the next PRs, I will add the 'add phase' and 'reorder phase' for users to have full control over their roadmaps. 

I just copied the modal edit for the milestone edit and just made some small changes to work for the phase.

**Before**
<img width="1721" height="743" alt="new23" src="https://github.com/user-attachments/assets/a97b1a10-f5d6-4c9a-9ddc-7690a434d1cd" />

 **After**
<img width="1708" height="838" alt="Screenshot 2025-07-30 at 8 05 01 AM" src="https://github.com/user-attachments/assets/b30fde24-b3ad-4fb5-a035-2a2b947b76a6" />

**Video Description**
<div>
    <a href="https://www.loom.com/share/d1197b3f6b8d4d5282de6ba98c6c5fc8">
      <p>Editing Face Titles and Features - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/d1197b3f6b8d4d5282de6ba98c6c5fc8">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/d1197b3f6b8d4d5282de6ba98c6c5fc8-88d5b6a7d408ee88-full-play.gif">
    </a>
  </div>