### PR TITLE
feat: add phase creation functionality

### DIFF
--- a/frontend/src/components/Roadmap/PhaseCardNew.jsx
+++ b/frontend/src/components/Roadmap/PhaseCardNew.jsx
@@ -67,7 +67,7 @@ const PhaseCardNew = ({ phase, onClick, onEdit }) => {
       className={`${COLOR_PATTERNS.landing.card} border-l-4 ${phaseColorClasses} cursor-pointer`}
       onClick={onClick}
     >
-      <div className="px-2 py-4">
+      <div className="px-1 py-4">
         {/* Header */}
         <div className="mb-3 flex items-start justify-between">
           <div className="min-w-0 flex-1">

--- a/frontend/src/constants/messages.js
+++ b/frontend/src/constants/messages.js
@@ -11,7 +11,11 @@ export const MESSAGES = {
     FILE_PROCESSED: '✓ Document processed successfully!',
     MILESTONE_MOVED_UP: 'Milestone moved up successfully',
     MILESTONE_MOVED_DOWN: 'Milestone moved down successfully',
-    PHASE_UPDATED: 'Phase updated successfully',
+              PHASE_UPDATED: 'Phase updated successfully',
+          PHASE_CREATED: 'Phase created successfully',
+        },
+        PLACEHOLDERS: {
+          PHASE_TIMELINE: 'Not yet set',
   },
   ERROR: {
     PROJECT_SAVE_FAILED: 'Failed to save project. Please try again.',

--- a/frontend/src/pages/ProjectDetail/ProjectDetailPage.jsx
+++ b/frontend/src/pages/ProjectDetail/ProjectDetailPage.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import { Plus } from 'lucide-react';
 import Button from '@/components/Button/Button';
 import LoadingSpinner from '@/components/Loading/LoadingSpinner';
 import PhaseCardNew from '@/components/Roadmap/PhaseCardNew';
@@ -24,7 +25,7 @@ import { QUERY_KEYS } from '@/constants/cache';
  * - After any edit (reorder, add, delete), invalidates the cache.
  * - On refresh or revisit, always shows the latest data after edits.
  * - Cache timing and keys are managed in the config file.
- * 
+ *
  * Features:
  * - Card-based phase layout similar to dashboard
  * - Responsive grid layout for phase cards
@@ -51,6 +52,7 @@ const ProjectDetailPage = () => {
   const [selectedPhase, setSelectedPhase] = useState(null);
   const [isEditPhaseModalOpen, setIsEditPhaseModalOpen] = useState(false);
   const [editingPhase, setEditingPhase] = useState(null);
+  const [isCreatePhaseModalOpen, setIsCreatePhaseModalOpen] = useState(false);
   const queryClient = useQueryClient();
 
   // Debounced persist function to minimize network overhead during rapid interactions
@@ -194,6 +196,20 @@ const ProjectDetailPage = () => {
   };
 
   /**
+   * Opens phase create modal
+   */
+  const handleCreatePhase = () => {
+    setIsCreatePhaseModalOpen(true);
+  };
+
+  /**
+   * Closes phase create modal
+   */
+  const handleCloseCreatePhaseModal = () => {
+    setIsCreatePhaseModalOpen(false);
+  };
+
+  /**
    * Saves phase edits and updates roadmap data
    * @param {Object} updatedPhase - Updated phase data
    */
@@ -216,6 +232,24 @@ const ProjectDetailPage = () => {
 
     // Show immediate success feedback
     showSuccessToast(MESSAGES.SUCCESS.PHASE_UPDATED);
+  };
+
+  /**
+   * Saves new phase and adds it to roadmap data
+   * @param {Object} newPhase - New phase data
+   */
+  const handleSaveNewPhase = (newPhase) => {
+    setRoadmapData((prevRoadmap) => {
+      const updatedRoadmap = { ...prevRoadmap, phases: [...prevRoadmap.phases, newPhase] };
+
+      // Save to backend
+      persistRoadmap(updatedRoadmap);
+
+      return updatedRoadmap;
+    });
+
+    // Show immediate success feedback
+    showSuccessToast(MESSAGES.SUCCESS.PHASE_CREATED);
   };
 
   /**
@@ -392,9 +426,19 @@ const ProjectDetailPage = () => {
 
                 {/* Phase Cards Grid */}
                 <div className="space-y-6">
-                  <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
-                    Project Phases
-                  </h2>
+                  <div className="flex items-center justify-between">
+                    <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
+                      Project Phases
+                    </h2>
+                    <button
+                      onClick={handleCreatePhase}
+                      className="flex items-center space-x-2 rounded-lg border border-blue-600 bg-blue-600 px-3 py-2 text-sm font-medium text-white shadow-sm transition-all duration-200 hover:border-green-600 hover:bg-green-600 hover:shadow-md"
+                      aria-label="Add new phase"
+                    >
+                      <Plus className="h-4 w-4" />
+                      <span>Add Phase</span>
+                    </button>
+                  </div>
                   <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
                     {roadmapData.phases.map((phase) => (
                       <PhaseCardNew
@@ -422,6 +466,15 @@ const ProjectDetailPage = () => {
                 onClose={handleCloseEditPhaseModal}
                 phase={editingPhase}
                 onSave={handleSavePhaseEdit}
+              />
+
+              {/* Create Phase Modal */}
+              <EditPhaseModal
+                isOpen={isCreatePhaseModalOpen}
+                onClose={handleCloseCreatePhaseModal}
+                phase={null}
+                onSave={handleSaveNewPhase}
+                nextOrder={roadmapData.phases.length + 1}
               />
             </>
           ) : (


### PR DESCRIPTION
**Features**
- Extended EditPhaseModal to support both edit and create modes
- Add timeline field to phase creation form with optional validation
- Add 'Add Phase' button to ProjectDetailPage with proper styling
- Add phase creation handlers and state management


**How it works**
User clicks on add phase, then a modal appears for them to put in the phase title and an optiional timeline. When the phase is created, the milestones and task fields will be empty for them to also add milestones and tasks, since they just created the phase. 

TODO: Add phase deletion and reordering in the next PRs

**Before**
<img width="1708" height="838" alt="Screenshot 2025-07-30 at 8 05 01 AM" src="https://github.com/user-attachments/assets/5fe8db4b-80ef-4ab0-a5ef-79f8842c32f2" />

**After**
<img width="1708" height="790" alt="Screenshot 2025-07-30 at 8 17 11 AM" src="https://github.com/user-attachments/assets/c66ebd03-b886-4483-9564-7560f314ff15" />


**Video Description**
<div>
    <a href="https://www.loom.com/share/5c4e4a07863848c2afa76a0c8d72024d">
      <p>Setting Up the New Face Feature - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/5c4e4a07863848c2afa76a0c8d72024d">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/5c4e4a07863848c2afa76a0c8d72024d-d20439f5de62ebff-full-play.gif">
    </a>
  </div>
