### PR TITLE
feat: added phase reordering functionality with previous/next buttons

### DIFF
--- a/frontend/src/components/Roadmap/PhaseCardNew.jsx
+++ b/frontend/src/components/Roadmap/PhaseCardNew.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Calendar, Clock, CheckCircle, Edit2, Trash2 } from 'lucide-react';
+import { Calendar, Clock, CheckCircle, Edit2, Trash2, ArrowLeft, ArrowRight } from 'lucide-react';
 import { calculatePhaseProgress } from '@/utils/roadmapUtils';
 import { TASK_STATUS } from '@/constants/roadmap';
+import { getButtonClasses, getDisabledButtonClasses } from '@/utils/buttonUtils';
 import { COLOR_CLASSES, COLOR_PATTERNS } from '@/constants/colors';
 import { getPhaseColor } from '@/utils/roadmapUtils';
 
@@ -35,8 +36,11 @@ import { getPhaseColor } from '@/utils/roadmapUtils';
  * @param {Function} [props.onClick] - Optional click handler for opening modal
  * @param {Function} [props.onEdit] - Optional edit handler for editing phase title
  * @param {Function} [props.onDelete] - Optional delete handler for deleting phase
+ * @param {Function} [props.onReorder] - Optional reorder handler for reordering phase
+ * @param {boolean} [props.isFirst] - Whether this is the first phase
+ * @param {boolean} [props.isLast] - Whether this is the last phase
  */
-const PhaseCardNew = ({ phase, onClick, onEdit, onDelete }) => {
+const PhaseCardNew = ({ phase, onClick, onEdit, onDelete, onReorder, isFirst, isLast }) => {
   // Calculate phase progress percentage (0-100)
   const progress = calculatePhaseProgress(phase);
 
@@ -141,6 +145,42 @@ const PhaseCardNew = ({ phase, onClick, onEdit, onDelete }) => {
             <span>{phase.milestones ? phase.milestones.length : 0} milestones</span>
           </div>
         </div>
+
+        {/* Reorder Controls */}
+        {onReorder && (
+          <div className="mt-3 flex justify-end space-x-1">
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onReorder(phase.id, 'previous');
+              }}
+              disabled={isFirst}
+              className={`rounded p-1 transition-colors ${getButtonClasses(
+                isFirst,
+                `${COLOR_CLASSES.surface.cardHover} ${COLOR_CLASSES.action.reorder.hover}`,
+                getDisabledButtonClasses()
+              )}`}
+              aria-label="Move phase earlier"
+            >
+              <ArrowLeft className={`h-4 w-4 ${COLOR_CLASSES.action.reorder.icon}`} />
+            </button>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onReorder(phase.id, 'next');
+              }}
+              disabled={isLast}
+              className={`rounded p-1 transition-colors ${getButtonClasses(
+                isLast,
+                `${COLOR_CLASSES.surface.cardHover} ${COLOR_CLASSES.action.reorder.hover}`,
+                getDisabledButtonClasses()
+              )}`}
+              aria-label="Move phase later"
+            >
+              <ArrowRight className={`h-4 w-4 ${COLOR_CLASSES.action.reorder.icon}`} />
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/constants/messages.js
+++ b/frontend/src/constants/messages.js
@@ -14,6 +14,7 @@ export const MESSAGES = {
     PHASE_UPDATED: 'Phase updated successfully',
     PHASE_CREATED: 'Phase created successfully',
     PHASE_DELETED: 'Phase deleted successfully',
+    PHASE_REORDERED: 'Phase reordered successfully',
   },
   PLACEHOLDERS: {
     PHASE_TIMELINE: 'Not yet set',


### PR DESCRIPTION
**Feature**
- Add reorder buttons (ArrowLeft/ArrowRight) to PhaseCardNew component
- Add PHASE_REORDERED success message to constants
- Reuse existing button utilities (getButtonClasses, getDisabledButtonClasses)

I essentially copied the milestone reordering functionality and just made some small changes to work for the phase with the same logic. Users are able to move the phase from left to right or otherwise. If the phase is first or last, the arrow buttons are disabled. 

**Before**
<img width="1721" height="718" alt="Screenshot 2025-07-30 at 8 31 09 AM" src="https://github.com/user-attachments/assets/345f2a0f-ef96-4eef-a602-7b29e1a0d375" />


**After**
<img width="1708" height="710" alt="Screenshot 2025-07-30 at 8 41 29 AM" src="https://github.com/user-attachments/assets/beb3455a-2eb2-4cec-a49a-b51ad7c16e7b" />


**Video Description**
https://www.loom.com/share/5735d40b0c624f7e88a4d24df8ca2882?sid=ca375978-773d-4b11-b57a-a943d611cf06